### PR TITLE
Fix GitHub spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The home of the [hapi.dev](http://hapi.dev) developer portal.
 
 * Next, you need to make an .env file in the root directory. 
 
-* Obtain a token from Github [here](https://github.com/settings/tokens/new) and select checked scopes only (only two)
+* Obtain a token from GitHub [here](https://github.com/settings/tokens/new) and select checked scopes only (only two)
 
   - [ ] **repo**              :   *Full control of private repositories*
     - [x] **repo status**     :   *Access commit status*
@@ -18,7 +18,7 @@ The home of the [hapi.dev](http://hapi.dev) developer portal.
     - [x] **public_repo**     :   *Access public repositories*
     - [ ] **repo:invite**     :   *Access repository invitations*
 
-* Copy your Github token and place it in your .env file by entering:
+* Copy your GitHub token and place it in your .env file by entering:
 ```GITHUB_TOKEN = "YOUR TOKEN"```
 
 * Run ```npm run dev``` and go to ```http://localhost:3000``` to view the site. The dev server hot loads, which will automatically show your changes without having to restart the server. 

--- a/components/Footers/Footer.vue
+++ b/components/Footers/Footer.vue
@@ -2,7 +2,7 @@
   <footer class="footer">
     <ul class="footer-links">
       <li class="footer-links-li">
-        <a class="footer-link" title="Github" target="__blank" href="https://github.com/hapijs/hapi">Github</a>
+        <a class="footer-link" title="GitHub" target="__blank" href="https://github.com/hapijs/hapi">GitHub</a>
       </li>
       <li class="footer-links-li">
         <a class="footer-link" title="Twitter" target="__blank" href="https://twitter.com/hapijs">Twitter</a>

--- a/components/Footers/SideFooter.vue
+++ b/components/Footers/SideFooter.vue
@@ -2,7 +2,7 @@
   <footer class="side-footer">
     <ul class="footer-links">
       <li class="footer-links-li">
-        <a class="footer-link" title="Github" target="__blank" href="https://github.com/hapijs/hapi">Github</a>
+        <a class="footer-link" title="GitHub" target="__blank" href="https://github.com/hapijs/hapi">GitHub</a>
       </li>
       <li class="footer-links-li">
         <a class="footer-link" title="Twitter" target="_blank" href="https://twitter.com/hapijs">Twitter</a>

--- a/static/lib/resources.md
+++ b/static/lib/resources.md
@@ -12,9 +12,9 @@
 
     Packed with examples, this book takes you from your first simple server through the skills you'll need to build a complete application. In it, you'll learn how to build websites and APIs, implement caching, authentication, validation, error handling, and a lot more. You'll also explore vital techniques for production applications, such as testing, monitoring, deployment, and documentation.
 
-*   [hapi with Typescript <img src="/img/hapiTypescript.png" class="resources-book" />](http://hapibook.jjude.com)
+*   [hapi with TypeScript <img src="/img/hapiTypescript.png" class="resources-book" />](http://hapibook.jjude.com)
 
-    This book introduces Typescript into developing web applications with hapi. Typescript, a language developed by Microsoft, brings the benefits of strong types and object-oriented programming to Javascript. With ample code samples, this book teaches all aspects of developing a web application in hapi with Typescript. It also introduces, hapidock, a docker container with all required components for developing in hapi. With hapidock, you can develop and test hapi applications in a production-like environment. Through this book, you will learn to build stable enterprise-level server applications. The book is free to read at http://hapibook.jjude.com. E-books (pdf, mobi, and epub) and fully executable code samples are available after purchase.
+    This book introduces TypeScript into developing web applications with hapi. TypeScript, a language developed by Microsoft, brings the benefits of strong types and object-oriented programming to JavaScript. With ample code samples, this book teaches all aspects of developing a web application in hapi with TypeScript. It also introduces, hapidock, a docker container with all required components for developing in hapi. With hapidock, you can develop and test hapi applications in a production-like environment. Through this book, you will learn to build stable enterprise-level server applications. The book is free to read at http://hapibook.jjude.com. E-books (pdf, mobi, and epub) and fully executable code samples are available after purchase.
 
 *   [Hapi.js Handbook <img src="/img/hapiHandbook.png" class="resources-book" />](https://leanpub.com/hapi-handbook)
 
@@ -134,7 +134,7 @@
 
 *   [typehapily](https://github.com/tejzpr/typehapily)
 
-    A Typescript based boilerplate for HAPIJS with TypeORM & Dynamic Linting
+    A TypeScript based boilerplate for HAPIJS with TypeORM & Dynamic Linting
 
 ## <a name="projects"></a> Projects built with hapi.js
 

--- a/static/lib/tutorials/en_US/expresstohapi.md
+++ b/static/lib/tutorials/en_US/expresstohapi.md
@@ -465,7 +465,7 @@ server.route({
 
 ## <a name="bell" ></a> Passport -> bell
 
-In Express, third party authentication is handled with Passport. In hapi, you use the [bell](/family/bell) module for third party authentication. `bell` has over 30 predefined configurations for OAuth providers including Twitter, Facebook, Google, Github, and more. It will also allow you to set up your own custom provider. For a complete list, please see the [bell providers documentation](https://github.com/hapijs/bell/blob/master/Providers.md). `bell` was developed and is maintained by the core hapi team, so you know stability and reliability won't be an issue. Lets look how to authenticate using your Twitter credentials:
+In Express, third party authentication is handled with Passport. In hapi, you use the [bell](/family/bell) module for third party authentication. `bell` has over 30 predefined configurations for OAuth providers including Twitter, Facebook, Google, GitHub, and more. It will also allow you to set up your own custom provider. For a complete list, please see the [bell providers documentation](https://github.com/hapijs/bell/blob/master/Providers.md). `bell` was developed and is maintained by the core hapi team, so you know stability and reliability won't be an issue. Lets look how to authenticate using your Twitter credentials:
 
 Express:
 ```js


### PR DESCRIPTION
Just a couple of minor spelling fixes: `Github` -> `GitHub` etc.