### PR TITLE
Adds missing quotes to the handler tutorial.

### DIFF
--- a/static/lib/tutorials/en_US/expresstohapi.md
+++ b/static/lib/tutorials/en_US/expresstohapi.md
@@ -192,9 +192,9 @@ server.route({
     handler: function (request, h) {
 
         const user = {
-            firstName: John,
-            lastName: Doe,
-            userName: JohnDoe,
+            firstName: 'John',
+            lastName: 'Doe',
+            userName: 'JohnDoe',
             id: 123
         }
 


### PR DESCRIPTION
The `user` object should get string literals with the according values, not be undefined variable names.