### PR TITLE
Slogan property does not exist

### DIFF
--- a/pages/family/index.vue
+++ b/pages/family/index.vue
@@ -97,7 +97,7 @@ export default {
       for (let module of this.moduleData) {
         if (
           !module.name.includes(this.$data.search.toLowerCase()) &&
-          !module.slogan.toLowerCase().includes(this.$data.search.toLowerCase())
+          !module.name.toLowerCase().includes(this.$data.search.toLowerCase())
         ) {
           document.querySelector("#" + module.name).classList.add("hide");
         }

--- a/pages/family/index.vue
+++ b/pages/family/index.vue
@@ -97,7 +97,7 @@ export default {
       for (let module of this.moduleData) {
         if (
           !module.name.includes(this.$data.search.toLowerCase()) &&
-          !module.name.toLowerCase().includes(this.$data.search.toLowerCase())
+          !module.slogan.toLowerCase().includes(this.$data.search.toLowerCase())
         ) {
           document.querySelector("#" + module.name).classList.add("hide");
         }
@@ -140,6 +140,7 @@ export default {
           stars: await Number(forks.stargazers_count),
           date: await forks.pushed_at,
           updated: await date.toDateString(),
+          slogan: await forks.description,
           link: "https://github.com/hapijs/" + module
         });
       } catch (err) {


### PR DESCRIPTION
Hi,

The search functionality in the modules page has the following error right now:

![search-module](https://user-images.githubusercontent.com/461124/71790661-94edcd80-2fff-11ea-8ed3-0058dbf02e66.PNG)

Reading the code I can see it's looking for an unexisting **slogan** property. Adding the slogan property works.

Demo: https://affectionate-colden-f04a38.netlify.com/family/?sort=name