### PR TITLE
updates require statements and joi payload validation

### DIFF
--- a/static/lib/tutorials/en_US/expresstohapi.md
+++ b/static/lib/tutorials/en_US/expresstohapi.md
@@ -603,7 +603,7 @@ npm install @hapi/joi
 <br />
 
 ```js
-const Joi = require('joi')
+const Joi = require('@hapi/joi')
 
 server.route({
     method: 'POST',
@@ -614,9 +614,9 @@ server.route({
     },
     options: {
         validate: {
-            payload: {
+            payload: Joi.object({
                 post: Joi.string().max(140)
-            }
+            })
         }
     }
 });
@@ -673,7 +673,7 @@ app.set('view engine', 'pug');
 
 To set the views engine in hapi, you first must register the vision plugin, then configure `server.views`:
 ```js
-await server.register(require('vision'));
+await server.register(require('@hapi/vision'));
 
 server.views({
     engines: {


### PR DESCRIPTION
The latest versions of hapi/joi require wrapping the payload with `Joi.object()` (see issue [2107](https://github.com/hapijs/joi/issues/2107)).

The also updates a couple of `require()` statements that didn't have the `@hapi` namespace.