### PR TITLE
Add Wildcard to list of plugins

### DIFF
--- a/static/lib/plugins.md
+++ b/static/lib/plugins.md
@@ -438,6 +438,10 @@ There are dozens of plugins for hapi, ranging from documentation to authenticati
 *   [wurst](https://github.com/felixheck/wurst)
 
     Directory based autoloader for routes
+    
+*   [Wildcard API](https://github.com/reframejs/wildcard-api)
+
+    RPC implementation for browser ⇔ Node.js communication.
 
 ## <a name="validation"></a> Validation
 


### PR DESCRIPTION
Hi!

First of all thanks for hapi, I really enjoy using it :-).

I'm not sure if Wildcard fits the list of plugins? It's an RPC implementation that has a hapi plugin (see https://github.com/reframejs/wildcard-api#getting-started).

Also, how about creating a new section "API"? I can change my PR to create a new API section, if you are interested.