### PR TITLE
fix: set align-items for module-version-wrapper links

### DIFF
--- a/assets/styles/statusTable.scss
+++ b/assets/styles/statusTable.scss
@@ -140,15 +140,11 @@
   border-bottom: 1px solid $dark-white;
 }
 
-.module-version-wrapper {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-}
-
+.module-version-wrapper,
 .module-version-wrapper a {
   display: flex;
   justify-content: center;
+  align-items: center;
 }
 
 .version-name {


### PR DESCRIPTION
First of all, thanks for this amazing framework and documentation!

---

There is a visual bug when opening a module page in Safari which looks like this:

Example https://hapi.dev/family/accept/ in Safari 13 (Safari Technology Preview has the same issue)
![Screenshot 2020-02-26 at 16 05 07](https://user-images.githubusercontent.com/5798652/75357682-0b95a180-58b2-11ea-9272-b28e27762018.png)

My fix brings the visuals in line with other browsers:
![Screenshot 2020-02-26 at 16 08 47](https://user-images.githubusercontent.com/5798652/75357854-51eb0080-58b2-11ea-916f-324c2786a9c6.png)

Please let me know if there are parts of the application this change could interfere with.
