### PR TITLE
Fix express to hapi getting cookies

### DIFF
--- a/static/lib/tutorials/en_US/expresstohapi.md
+++ b/static/lib/tutorials/en_US/expresstohapi.md
@@ -414,7 +414,7 @@ const Hapi = require('@hapi/hapi');
 
 const server = Hapi.server({ port: 8000 });
 
-server.state('data', {
+server.state('username', {
     ttl: null,
     isSecure: true,
     isHttpOnly: true
@@ -425,7 +425,7 @@ server.route({
     path: '/',
     handler: async (request, h) => {
 
-        await h.state('data', {username: 'tom'});
+        await h.state('username', 'tom');
         return h.response(request.state.username);
     }
 });


### PR DESCRIPTION
This is an extension for the #331 fix because the "Getting a cookie value" section also used an object wrapper.