### PR TITLE
fix documentation

### DIFF
--- a/static/lib/tutorials/en_US/expresstohapi.md
+++ b/static/lib/tutorials/en_US/expresstohapi.md
@@ -67,7 +67,7 @@ hapi:
 ```js
 server.route({
     method: 'GET',
-    path:'/',
+    path:'/hello',
     handler: (request, h) => {
 
       return 'Hello World!';


### PR DESCRIPTION
hello was missing in the path. I have fixed it. Documentation remain consistent.
url: https://hapi.dev/tutorials/expresstohapi/?lang=en_US