### PR TITLE
[update-hapi17-docs] Update all hapi 17 tutorials to use scoped hapi packages

### DIFF
--- a/static/lib/tutorials/en_US/servingfiles.md
+++ b/static/lib/tutorials/en_US/servingfiles.md
@@ -9,7 +9,7 @@ Inevitably while building any web application, the need arises to serve a simple
 
 First you need to install and add `inert` as a dependency to your project:
 
-`npm install inert`
+`npm install @hapi/inert`
 
 ## <a name="inert"></a> Inert
 
@@ -22,7 +22,7 @@ To simplify things, especially if you have multiple routes that respond with fil
 ```javascript
 'use strict';
 
-const Hapi = require('hapi');
+const Hapi = require('@hapi/hapi');
 const Path = require('path');
 
 const start = async () => {
@@ -35,7 +35,7 @@ const start = async () => {
         }
     });
 
-    await server.register(require('inert'));
+    await server.register(require('@hapi/inert'));
 
     server.route({
         method: 'GET',
@@ -65,7 +65,7 @@ const start = async () => {
 
     const server = Hapi.server();
 
-    await server.register(require('inert'));
+    await server.register(require('@hapi/inert'));
 
     server.route({
         method: 'GET',
@@ -187,8 +187,8 @@ One common case for serving static content is setting up a file server. The foll
 
 ```js
 const Path = require('path');
-const Hapi = require('hapi');
-const Inert = require('inert');
+const Hapi = require('@hapi/hapi');
+const Inert = require('@hapi/inert');
 
 const init = async () => {
 

--- a/static/lib/tutorials/ko_KR/auth.md
+++ b/static/lib/tutorials/ko_KR/auth.md
@@ -12,7 +12,7 @@ hapi에서 인증은 `schemes`와 `strategies` 개념을 기반으로 하고 있
 'use strict';
 
 const Bcrypt = require('bcrypt');
-const Hapi = require('hapi');
+const Hapi = require('@hapi/hapi');
 
 const users = {
     john: {

--- a/static/lib/tutorials/ko_KR/caching.md
+++ b/static/lib/tutorials/ko_KR/caching.md
@@ -86,7 +86,7 @@ hapi는 [catbox_memory](https://github.com/hapijs/catbox-memory) 어댑터를 �
 ```javascript
 'use strict';
 
-const Hapi = require('hapi');
+const Hapi = require('@hapi/hapi');
 
 const server = Hapi.server({
     port: 8000,

--- a/static/lib/tutorials/ko_KR/gettingstarted.md
+++ b/static/lib/tutorials/ko_KR/gettingstarted.md
@@ -8,7 +8,7 @@ _이 튜터리얼은 hapi v17과 호환됩니다._
 
 * 실행: `cd myproject` 생성한 프로젝트 폴더로 이동합니다.
 * 실행: `npm init` 입력 후, 지시 메시지를 따르세요. package.json 파일을 생성할 것입니다.
-* 실행: `npm install --save hapi@17.x.x` 이 명령은 hapi를 설치하고 프로젝트 의존성을 package.json에 기록합니다.
+* 실행: `npm install --save @hapi/hapi@17.x.x` 이 명령은 hapi를 설치하고 프로젝트 의존성을 package.json에 기록합니다.
 
 이게 전부입니다! hapi를 사용하는 서버를 만드는 데 필요한 모든 것을 갖췄습니다.
 
@@ -19,7 +19,7 @@ _이 튜터리얼은 hapi v17과 호환됩니다._
 ```javascript
 'use strict';
 
-const Hapi = require('hapi');
+const Hapi = require('@hapi/hapi');
 
 const server = Hapi.server({
     port: 3000,
@@ -52,7 +52,7 @@ init();
 ```javascript
 'use strict';
 
-const Hapi = require('hapi');
+const Hapi = require('@hapi/hapi');
 
 const server = Hapi.server({
     port: 3000,
@@ -102,14 +102,14 @@ init();
 
 Hello World 응용프로그램으로 간단한 hapi 앱을 실행할 수 있음을 확인했습니다. 다음은 정적 페이지를 제공하는 **inert**라는 플러그인을 사용할 것입니다. 시작하기 전에 **CTRL + C**로 서버를 중지하세요.
 
-[inert](https://github.com/hapijs/inert)를 설치하려면 명령행에서 이 명령을 실행하세요.: `npm install --save inert` [inert](https://github.com/hapijs/inert)를 내려받고 설치된 패키지를 문서로 만든 `package.json`에 추가합니다.
+[inert](https://github.com/hapijs/inert)를 설치하려면 명령행에서 이 명령을 실행하세요.: `npm install --save @hapi/inert` [inert](https://github.com/hapijs/inert)를 내려받고 설치된 패키지를 문서로 만든 `package.json`에 추가합니다.
 
 `server.js` 파일에 `init` 함수를 변경합니다.:
 
 ``` javascript
 const init = async () => {
 
-    await server.register(require('inert'));
+    await server.register(require('@hapi/inert'));
 
     server.route({
         method: 'GET',
@@ -169,7 +169,7 @@ npm install hapi-pino
 ```javascript
 'use strict';
 
-const Hapi = require('hapi');
+const Hapi = require('@hapi/hapi');
 
 const server = Hapi.server({
     port: 3000,

--- a/static/lib/tutorials/ko_KR/servingfiles.md
+++ b/static/lib/tutorials/ko_KR/servingfiles.md
@@ -6,7 +6,7 @@ _이 튜터리얼은 hapi v17과 호환됩니다._
 
 먼저 inert 설치와 프로젝트에 의존성을 추가해야 합니다.:
 
-`npm install --save inert`
+`npm install --save @hapi/inert`
 
 ## `h.file(path, [options])`
 
@@ -15,7 +15,7 @@ _이 튜터리얼은 hapi v17과 호환됩니다._
 ```javascript
 const start = async () => {
 
-    await server.register(require('inert'));
+    await server.register(require('@hapi/inert'));
 
     server.route({
         method: 'GET',
@@ -43,7 +43,7 @@ start();
 ```javascript
 'use strict';
 
-const Hapi = require('hapi');
+const Hapi = require('@hapi/hapi');
 const Path = require('path');
 
 const server = Hapi.server({
@@ -56,7 +56,7 @@ const server = Hapi.server({
 
 const start = async () => {
 
-    await server.register(require('inert'));
+    await server.register(require('@hapi/inert'));
 
     server.route({
         method: 'GET',

--- a/static/lib/tutorials/ko_KR/views.md
+++ b/static/lib/tutorials/ko_KR/views.md
@@ -12,14 +12,14 @@ view를 시작하려면 먼저 서버에 최소한 하나의 템플릿 엔진을
 'use strict';
 
 const Path = require('path');
-const Hapi = require('hapi');
-const Hoek = require('hoek');
+const Hapi = require('@hapi/hapi');
+const Hoek = require('@hapi/hoek');
 
 const server = Hapi.server();
 
 const start = async () => {
 
-    await server.register(require('vision'));
+    await server.register(require('@hapi/vision'));
 
     server.views({
         engines: {
@@ -230,13 +230,13 @@ module.exports = function () {
 ```javascript
 'use strict';
 
-const Hapi = require('hapi');
+const Hapi = require('@hapi/hapi');
 
 const server = Hapi.server({ port: 8080 });
 
 const start = async () => {
 
-    await server.register(require('vision'));
+    await server.register(require('@hapi/vision'));
 
     server.views({
         engines: {

--- a/static/lib/tutorials/tr_TR/auth.md
+++ b/static/lib/tutorials/tr_TR/auth.md
@@ -12,7 +12,7 @@ hapide kimlik doğrulama şema (`schema`) ve stratejilerin (`strategy`) üzerine
 'use strict';
 
 const Bcrypt = require('bcrypt');
-const Hapi = require('hapi');
+const Hapi = require('@hapi/hapi');
 
 const users = {
     john: {

--- a/static/lib/tutorials/tr_TR/caching.md
+++ b/static/lib/tutorials/tr_TR/caching.md
@@ -88,7 +88,7 @@ hapi varsayılan olarak [catbox memory](https://github.com/hapijs/catbox-memory)
 ```javascript
 'use strict';
 
-const Hapi = require('hapi');
+const Hapi = require('@hapi/hapi');
 
 const server = Hapi.server({
     port: 8000,

--- a/static/lib/tutorials/tr_TR/gettingstarted.md
+++ b/static/lib/tutorials/tr_TR/gettingstarted.md
@@ -9,7 +9,7 @@ _Bu kurs hapi v17 ile uyumludur_
 
 * `cd myproject` komutunu çalıştırarak proje dizinine gir.
 * `npm init` komutunu çalıştırarak yönergeleri izle, bu komut senin için package.json dosyası oluşturur.
-* `npm install --save hapi@17.x.x` komutunu çalıştır. Bu komut hapiyi kurar ve package.json dosyasına gereksinim olarak kaydeder.
+* `npm install --save @hapi/hapi@17.x.x` komutunu çalıştır. Bu komut hapiyi kurar ve package.json dosyasına gereksinim olarak kaydeder.
 
 Hepsi bu kadar! Artık hapi kullanarak bir sunucu oluşturmak için ihtiyacın olan herşeye sahipsin.
 
@@ -20,7 +20,7 @@ En basit sunucu şöyle bir şeydir:
 ```javascript
 'use strict';
 
-const Hapi = require('hapi');
+const Hapi = require('@hapi/hapi');
 
 const server = Hapi.server({
     port: 3000,
@@ -55,7 +55,7 @@ Artık sunucumuz olduğuna göre, bir iki güzergah eklemeliyiz ki gerçekten bi
 ```javascript
 'use strict';
 
-const Hapi = require('hapi');
+const Hapi = require('@hapi/hapi');
 
 const server = Hapi.server({
     port: 3000,
@@ -105,14 +105,14 @@ name değiştirgesini URI encode (URI kodladığımıza) ettiğimize dikkat et, 
 
 Hello world uygulamamızla basit bir hapi uygulaması başlatabildiğimizi kanıtladık. Şimdi, **inert** denen bir eklenti kullarak durağan bir sayfa sunacağız. Başlamadan önce, **CTRL + C** tuşlarına basarak sunucuyu durdur.
 
-[inert](https://github.com/hapijs/inert)i kurmak için komut satırında `npm install --save inert` komutunu çalıştır. Bu, [inert](https://github.com/hapijs/inert)i indirerek hangi paketlerin kurulu olduğunu dokümante eden `package.json` dosyana ekleyecek.
+[inert](https://github.com/hapijs/inert)i kurmak için komut satırında `npm install --save @hapi/inert` komutunu çalıştır. Bu, [inert](https://github.com/hapijs/inert)i indirerek hangi paketlerin kurulu olduğunu dokümante eden `package.json` dosyana ekleyecek.
 
 `server.js` dosyasını açarak `init` işlevini şu şekilde güncelle:
 
 ``` javascript
 const init = async () => {
 
-    await server.register(require('inert'));
+    await server.register(require('@hapi/inert'));
 
     server.route({
         method: 'GET',
@@ -173,7 +173,7 @@ Sonra `server.js` dosyasını güncelle:
 ```javascript
 'use strict';
 
-const Hapi = require('hapi');
+const Hapi = require('@hapi/hapi');
 
 const server = Hapi.server({
     port: 3000,

--- a/static/lib/tutorials/tr_TR/servingfiles.md
+++ b/static/lib/tutorials/tr_TR/servingfiles.md
@@ -6,7 +6,7 @@ Bir ağ uygulaması yazarken eninde sonunda diskten bir dosya sunmanın vakti ge
 
 Önce inerti projene gereksinim olarak ekleyerek kurmalısın:
 
-`npm install --save inert`
+`npm install --save @hapi/inert`
 
 ## `h.file(path, [options])`
 
@@ -15,7 +15,7 @@ Bir ağ uygulaması yazarken eninde sonunda diskten bir dosya sunmanın vakti ge
 ```javascript
 const start = async () => {
 
-    await server.register(require('inert'));
+    await server.register(require('@hapi/inert'));
 
     server.route({
         method: 'GET',
@@ -43,7 +43,7 @@ Yukarıda göreceğin gibi, en basit haliyle `h.file(path)` dönüyorsun.
 ```javascript
 'use strict';
 
-const Hapi = require('hapi');
+const Hapi = require('@hapi/hapi');
 const Path = require('path');
 
 const server = Hapi.server({
@@ -56,7 +56,7 @@ const server = Hapi.server({
 
 const start = async () => {
 
-    await server.register(require('inert'));
+    await server.register(require('@hapi/inert'));
 
     server.route({
         method: 'GET',

--- a/static/lib/tutorials/tr_TR/views.md
+++ b/static/lib/tutorials/tr_TR/views.md
@@ -12,14 +12,14 @@ Kullanıcı arayüzlerine (view) başlamak için önce en sunucuda en az bir şa
 'use strict';
 
 const Path = require('path');
-const Hapi = require('hapi');
-const Hoek = require('hoek');
+const Hapi = require('@hapi/hapi');
+const Hoek = require('@hapi/hoek');
 
 const server = Hapi.server();
 
 const start = async () => {
 
-    await server.register(require('vision'));
+    await server.register(require('@hapi/vision'));
 
     server.views({
         engines: {
@@ -230,13 +230,13 @@ Aşağıda referans olarak, şablonunda fortune (kısmet) kullanıcı arayüzü 
 ```javascript
 'use strict';
 
-const Hapi = require('hapi');
+const Hapi = require('@hapi/hapi');
 
 const server = Hapi.server({ port: 8080 });
 
 const start = async () => {
 
-    await server.register(require('vision'));
+    await server.register(require('@hapi/vision'));
 
     server.views({
         engines: {

--- a/static/lib/tutorials/zh_CN/auth.md
+++ b/static/lib/tutorials/zh_CN/auth.md
@@ -12,7 +12,7 @@ hapi 的身份认证基于两个概念：`schemes` 和 `strategies`。
 'use strict';
 
 const Bcrypt = require('bcrypt');
-const Hapi = require('hapi');
+const Hapi = require('@hapi/hapi');
 
 const users = {
     john: {

--- a/static/lib/tutorials/zh_CN/caching.md
+++ b/static/lib/tutorials/zh_CN/caching.md
@@ -85,7 +85,7 @@ hapi 通过 [catbox memory](https://github.com/hapijs/catbox-memory) 适配器�
 ```javascript
 'use strict';
 
-const Hapi = require('hapi');
+const Hapi = require('@hapi/hapi');
 
 const server = Hapi.server({
     port: 8000,

--- a/static/lib/tutorials/zh_CN/gettingstarted.md
+++ b/static/lib/tutorials/zh_CN/gettingstarted.md
@@ -8,7 +8,7 @@ _该教程适用于 hapi v17版本_
 
 * 运行: `cd myproject` 跳转到目录内。
 * 运行: `npm init` 根据提示生成文件 package.json。
-* 运行: `npm install --save hapi@17.x.x` 将安装 hapi ，并将相应的依赖并保存至 package.json 中。
+* 运行: `npm install --save @hapi/hapi@17.x.x` 将安装 hapi ，并将相应的依赖并保存至 package.json 中。
 
 就是这么简单! 你现在已经做好了创建一个 hapi 应用的全部准备。
 
@@ -19,7 +19,7 @@ _该教程适用于 hapi v17版本_
 ```javascript
 'use strict';
 
-const Hapi = require('hapi');
+const Hapi = require('@hapi/hapi');
 
 const server = Hapi.server({
     port: 3000,
@@ -52,7 +52,7 @@ Web 服务器可以通过以下方式创建：指定主机名、填写IP地址�
 ```javascript
 'use strict';
 
-const Hapi = require('hapi');
+const Hapi = require('@hapi/hapi');
 
 const server = Hapi.server({
     port: 3000,
@@ -102,14 +102,14 @@ init();
 
 我们已经验证了了可以使用 Hello World 应用程序启动一个简单的hapi应用。 之后我们将使用一个名为 **inert** 的插件去创建静态页面。 在你开始之前，通过命令 **CTRL + C** 停止你的服务器。
 
-安装 [inert](https://github.com/hapijs/inert) 使用以下命令: `npm install --save inert` 这将会下载 [inert](https://github.com/hapijs/inert) 包，并且将其添加到用于记录依赖的 `package.json` 文件中。
+安装 [inert](https://github.com/hapijs/inert) 使用以下命令: `npm install --save @hapi/inert` 这将会下载 [inert](https://github.com/hapijs/inert) 包，并且将其添加到用于记录依赖的 `package.json` 文件中。
 
 在你的 `server.js` 文件中修改 `init` 函数如下:
 
 ``` javascript
 const init = async () => {
 
-    await server.register(require('inert'));
+    await server.register(require('@hapi/inert'));
 
     server.route({
         method: 'GET',
@@ -169,7 +169,7 @@ npm install hapi-pino
 ```javascript
 'use strict';
 
-const Hapi = require('hapi');
+const Hapi = require('@hapi/hapi');
 
 const server = Hapi.server({
     port: 3000,

--- a/static/lib/tutorials/zh_CN/servingfiles.md
+++ b/static/lib/tutorials/zh_CN/servingfiles.md
@@ -6,7 +6,7 @@ _该教程适用于 hapi v17版本_
 
 首先你需要安装它，并且将 inert 作为依赖添加到你的项目中:
 
-`npm install --save inert`
+`npm install --save @hapi/inert`
 
 ## `h.file(path, [options])`
 
@@ -15,7 +15,7 @@ _该教程适用于 hapi v17版本_
 ```javascript
 const start = async () => {
 
-    await server.register(require('inert'));
+    await server.register(require('@hapi/inert'));
 
     server.route({
         method: 'GET',
@@ -43,7 +43,7 @@ start();
 ```javascript
 'use strict';
 
-const Hapi = require('hapi');
+const Hapi = require('@hapi/hapi');
 const Path = require('path');
 
 const server = Hapi.server({
@@ -56,7 +56,7 @@ const server = Hapi.server({
 
 const start = async () => {
 
-    await server.register(require('inert'));
+    await server.register(require('@hapi/inert'));
 
     server.route({
         method: 'GET',

--- a/static/lib/tutorials/zh_CN/views.md
+++ b/static/lib/tutorials/zh_CN/views.md
@@ -12,14 +12,14 @@ hapi 对模板渲染有广泛的支持，包括加载以及使用多个模板引
 'use strict';
 
 const Path = require('path');
-const Hapi = require('hapi');
-const Hoek = require('hoek');
+const Hapi = require('@hapi/hapi');
+const Hoek = require('@hapi/hoek');
 
 const server = Hapi.server();
 
 const start = async () => {
 
-    await server.register(require('vision'));
+    await server.register(require('@hapi/vision'));
 
     server.views({
         engines: {
@@ -230,13 +230,13 @@ module.exports = function () {
 ```javascript
 'use strict';
 
-const Hapi = require('hapi');
+const Hapi = require('@hapi/hapi');
 
 const server = Hapi.server({ port: 8080 });
 
 const start = async () => {
 
-    await server.register(require('vision'));
+    await server.register(require('@hapi/vision'));
 
     server.views({
         engines: {


### PR DESCRIPTION
Recently noticed [#4085](https://github.com/hapijs/hapi/issues/4085). Turns out there were some outdated references to old hapi packages. I updated every tutorial claiming to support hapi >= 17 (older tutorials were left intact)