### PR TITLE
clarify `request.state` behavior when multiple cookies with the same name are present on the request

### DIFF
--- a/static/lib/tutorials/en_US/cookies.md
+++ b/static/lib/tutorials/en_US/cookies.md
@@ -100,7 +100,7 @@ In this example the cookie will simply be set to the string `"test"` with no enc
 
 Access a cookie’s value via `request.state` in a route handler, pre-requisite, or request lifecycle extension point.
 
-The `request.state` object contains the parsed HTTP state. Each key represents the cookie name and its value is the defined content.
+The `request.state` object contains the parsed HTTP state. Each key represents the cookie name and its value is the defined content.  If multiple cookies with the same name are present on the request, the values are exposed as an array rather than a single value.
 
 The sample code uses the `data` cookie key from above where the related value is set to `{ firstVisit: false }`:
 


### PR DESCRIPTION
When multiple cookies with the same name are present on a request, Statehood will expose those values as an array rather than a string:

https://github.com/hapijs/statehood/blob/master/lib/index.js#L118-L120

I think that this behavior is worth calling out in the docs to make developers aware that they may need to deal with both scenarios when accessing cookies via `request.state`.