### PR TITLE
Touchup the sponsors page to display sponsors lists more compactly

### DIFF
--- a/pages/policies/sponsors.vue
+++ b/pages/policies/sponsors.vue
@@ -78,9 +78,21 @@ export default {
   width: 100%;
 }
 
+.markdown-wrapper ul {
+  columns: 3;
+  li {
+    list-style: none;
+    border-left: 2px solid $orange;
+    padding-left: 15px;
+  }
+}
+
 @media screen and (max-width: 900px) {
   .community-wrapper {
     padding: 0 20px;
+  }
+  .markdown-wrapper ul {
+    columns: 2;
   }
 }
 </style>


### PR DESCRIPTION
I made some modest CSS changes on the sponsors page to display sponsors in a column layout.  My hope is to bring a touch of visual interest and to make better use of space on the page, ultimately giving our sponsors more visibility.

<img width="1437" alt="Screen Shot 2021-02-27 at 1 37 37 PM" src="https://user-images.githubusercontent.com/3150233/109396824-64eb4300-7901-11eb-8e88-1f2e496d7ebd.png">
