### PR TITLE
Add Optic plugin to available plugins list

### DIFF
--- a/static/lib/plugins.json
+++ b/static/lib/plugins.json
@@ -128,6 +128,12 @@
         "name": "hapi-swaggered-ui",
         "link": "https://github.com/z0mt3c/hapi-swaggered-ui",
         "description": "A plugin to serve and configure swagger-ui"
+      },
+      {
+        "name": "optic-hapi-middleware",
+        "github": "https://github.com/opticdev/optic-node/tree/main/frameworks/hapi",
+        "link": "https://www.npmjs.com/package/@useoptic/hapi-middleware",
+        "description": "Document API endpoints using Optic"
       }
     ]
   },


### PR DESCRIPTION
Add the Optic Hapi-middleware plugin to use Optic to document API endpoints