### PR TITLE
dark mode font colour of api search button changed from black to white

### DIFF
--- a/components/api/ApiNav.vue
+++ b/components/api/ApiNav.vue
@@ -711,7 +711,7 @@ export default {
   .api-search-button {
     border: 1px solid $dark-white;
     background: $white;
-    color: $black;
+    color: $white;
   }
 
 }


### PR DESCRIPTION
Hi! I think the issue is solved now. Have made the font for the buttons white but they can be changed to another like orange if preferred. I'm happy to help if that's wanted just let me know.

fix #478 