### PR TITLE
Fixed a typo

### DIFF
--- a/static/lib/tutorials/en_US/expresstohapi.md
+++ b/static/lib/tutorials/en_US/expresstohapi.md
@@ -178,7 +178,7 @@ To extend its functionality, Express uses middleware. Middleware essentially is 
 
 Plugins allow you to break your application logic into isolated pieces of business logic, and reusable utilities. Each plugin comes with its own dependencies which are explicitly specified in the plugins themselves. This means you don't have to install dependencies yourself to make your plugins work. You can either add an existing hapi plugin, or write your own. For a more extensive tutorial on plugins, please see the [plugins](/tutorials/plugins/?lang=en_US) tutorial.  
 
-Each request in hapi follows a predefined path, the request lifecycle. hapi has extension points that let you create custom functionality along the lifecycle. Extension points in hapi let you know the precise order at which you application will run. For more info, please see the hapi [request lifecycle](/api/#request-lifecycle).
+Each request in hapi follows a predefined path, the request lifecycle. hapi has extension points that let you create custom functionality along the lifecycle. Extension points in hapi let you know the precise order at which your application will run. For more info, please see the hapi [request lifecycle](/api/#request-lifecycle).
 
 ### <a name="extension" ></a> Extension Points
 


### PR DESCRIPTION
Under the topic - Middleware vs Plugins and Extensions
Last Paragraph, Second last line - "Extension points in hapi let you know the precise order at which you application will run."
Instead of "you application will run", "your application will run" should be there.