### PR TITLE
use black color on module status page, fix #497

### DIFF
--- a/pages/resources/status.vue
+++ b/pages/resources/status.vue
@@ -326,6 +326,7 @@ export default {
 
 .status-table td {
   padding: 10px;
+  color: $black;
 }
 
 .status-table tbody {


### PR DESCRIPTION
### Summary

Added `color: $black` on `.status-table td` regardless of the theme color.
Not sure if there are more white-background tables on the site, should move this style to the new selector in the future.

### Screenshots

- `prefers-color-scheme: dark`:
  ![module status page with dark theme screenshot](https://user-images.githubusercontent.com/9481405/163338284-a596676a-0e04-40e3-af18-e02947df88a9.png)
- `prefers-color-scheme: light`:
  ![module status page  with light theme screenshot](https://user-images.githubusercontent.com/9481405/163339686-d5ea6b27-b287-49ae-86fa-3bbd49df56fa.png)

### References

- [Module Status - hapi.dev](https://hapi.dev/resources/status/)
- #497