### PR TITLE
Update plugins.json

### DIFF
--- a/static/lib/plugins.json
+++ b/static/lib/plugins.json
@@ -264,11 +264,6 @@
         "name": "hapi-audit-rest",
         "link": "https://github.com/denlap007/hapi-audit-rest",
         "description": "Hapi.js plugin that generates audit logs for RESTful APIs"
-      },
-      {
-        "name": "new relic",
-        "link": "https://github.com/newrelic/newrelic-quickstarts/tree/main/quickstarts/node-js/hapi",
-        "description": "Monitor your Hapi.js application performance using Node.js agent"
       }
     ]
   },

--- a/static/lib/plugins.json
+++ b/static/lib/plugins.json
@@ -264,6 +264,11 @@
         "name": "hapi-audit-rest",
         "link": "https://github.com/denlap007/hapi-audit-rest",
         "description": "Hapi.js plugin that generates audit logs for RESTful APIs"
+      },
+      {
+        "name": "new relic",
+        "link": "https://github.com/newrelic/newrelic-quickstarts/tree/main/quickstarts/node-js/hapi",
+        "description": "Monitor your Hapi.js application performance using Node.js agent"
       }
     ]
   },

--- a/static/lib/tutorials/en_US/logging.md
+++ b/static/lib/tutorials/en_US/logging.md
@@ -92,4 +92,4 @@ You can find more information on debug mode in the [API documentation](/api#serv
 
 ## <a name="plugins"></a>Logging Plugins
 
-The built-in methods provided by hapi for retrieving and printing logs are fairly minimal. For a more feature-rich logging experience, you can look into using a plugin like [hapi-pino](https://www.npmjs.com/package/hapi-pino), or any of the other [hapi logging plugins](/plugins#logging).
+The built-in methods provided by hapi for retrieving and printing logs are fairly minimal. For a more feature-rich logging experience, you can look into using a plugin like [hapi-pino](https://www.npmjs.com/package/hapi-pino), [New Relic](https://newrelic.com/instant-observability/hapi/2124da5b-0174-457a-be5a-e0068673b2b5) or any of the other [hapi logging plugins](/plugins#logging).


### PR DESCRIPTION
Hi Team, 
We have many users on our platform who are using Hapi and would like to instrument it.  We’d love to provide a smooth experience for Hapi users who need to use commercial monitoring solutions.  Please see our [documentation](https://docs.newrelic.com/docs/apm/agents/nodejs-agent/getting-started/introduction-new-relic-nodejs/) here.

Please consider adding a link for your direct users to provide an option for New Relic.  We propose the content submitted in this PR.
