### PR TITLE
Update example to return 404 error

### DIFF
--- a/static/lib/tutorials/en_US/routing.md
+++ b/static/lib/tutorials/en_US/routing.md
@@ -269,8 +269,7 @@ const init = async () => {
         method: '*',
         path: '/{any*}',
         handler: function (request, h) {
-
-            return '404 Error! Page Not Found!';
+            return h.response('404 Error! Page Not Found!').code(404);
         }
     });
 


### PR DESCRIPTION
Update tutorial documentation for the 404 routing example to return a 404 error code.

As raised in this issue: https://github.com/hapijs/hapi/issues/4434 