### PR TITLE
Add x-frame-options header for netlify

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Frame-Options = "SAMEORIGIN"


### PR DESCRIPTION
Sets the `x-frame-options: SAMEORIGIN` header when served by netlify.