### PR TITLE
Update blankie in plugins.json

### DIFF
--- a/static/lib/plugins.json
+++ b/static/lib/plugins.json
@@ -306,7 +306,7 @@
     "modules": [
       {
         "name": "blankie",
-        "link": "https://github.com/nlf/blankie",
+        "link": "https://github.com/arafel/blankie",
         "description": "A plugin that makes Content-Security-Policy headers easy"
       },
       {


### PR DESCRIPTION
'nlf' appears absent - I've tried emailing them with no response. In the meantime I have a fork where I've updated the necessary dependencies; maybe people could use that until (if?) the original author returns?