### PR TITLE
Add hapi-saml2 to list of plugins

### DIFF
--- a/static/lib/plugins.json
+++ b/static/lib/plugins.json
@@ -91,6 +91,11 @@
         "description": "A Hapi plugin that wraps passport-saml for SAML SSO"
       },
       {
+        "name": "hapi-saml2",
+        "link": "https://github.com/toriihq/hapi-saml2",
+        "description": "A Hapi plugin that wraps node-saml for SAML SSO"
+      },
+      {
         "name": "jwt",
         "isHapi": true,
         "github": "https://github.com/hapijs/jwt",


### PR DESCRIPTION
This adds https://www.npmjs.com/package/hapi-saml2 to the list of plugins.

Today only `hapi-passport-saml` is listed which has not been updated in years. 