### PR TITLE
Add Apitally to plugins.json

### DIFF
--- a/static/lib/plugins.json
+++ b/static/lib/plugins.json
@@ -248,6 +248,11 @@
     "anchor": "logging",
     "modules": [
       {
+        "name": "apitally",
+        "link": "https://github.com/apitally/apitally-js",
+        "description": "Simple API monitoring and analytics with metrics, logs, and alerts"
+      },
+      {
         "name": "apitraffic-hapi",
         "link": "https://github.com/apitraffic/apitraffic-hapi",
         "description": "Collects API request/response data for monitoring and analytical purposes"


### PR DESCRIPTION
Added Apitally to the list of plugins under Logging/Metrics.

Apitally is a simple API monitoring and analytics tool with an official hapi plugin.

Repo: https://github.com/apitally/apitally-js
Docs: https://docs.apitally.io/frameworks/hapi
Website: https://apitally.io/hapi