### PR TITLE
Add security plugin `ratli` to `plugins.json`

### DIFF
--- a/static/lib/plugins.json
+++ b/static/lib/plugins.json
@@ -352,6 +352,12 @@
         "name": "ralphi",
         "link": "https://github.com/yonjah/ralphi",
         "description": "Simple and minimal rate limiting and bruteforce protection"
+      },
+      {
+        "name": "ratli",
+        "link": "https://github.com/johnwatson484/ratli",
+        "github": "https://github.com/johnwatson484/ratli",
+        "description": "Hapi.js rate limiting plugin"
       }
     ]
   },


### PR DESCRIPTION
Adding new rate limiting plugin as only existing referenced plugin, [`ralphi`](https://github.com/yonjah/ralphi) is no longer maintained.