### PR TITLE
feat: update and add @ar4mirez hapi plugins (hapi v21)

### DIFF
--- a/static/lib/plugins.json
+++ b/static/lib/plugins.json
@@ -476,9 +476,9 @@
         "description": "Automatically load routes from directory"
       },
       {
-        "name": "hapi-aws",
+        "name": "@ar4mirez/hapi-aws",
         "link": "https://github.com/ar4mirez/hapi-aws",
-        "description": "A HapiJS plugin for AWS services."
+        "description": "AWS SDK v3 plugin for HapiJS — instantiate and expose AWS service clients via server and request decorators."
       },
       {
         "name": "hapi-bookshelf-serializer",
@@ -576,7 +576,7 @@
         "description": "A simple bridge plugin between HapiJS and SocketIO"
       },
       {
-        "name": "hapi-octopus",
+        "name": "@ar4mirez/hapi-octopus",
         "link": "https://github.com/ar4mirez/hapi-octopus",
         "description": "A multi-purpose plugin that allows you to autoload methods, handlers, routes and decorators using a simple signature convention."
       },
@@ -599,6 +599,11 @@
         "name": "hapi-plugin-header",
         "link": "https://github.com/rse/hapi-plugin-header",
         "description": "Always send one or more custom HTTP headers, independent of the current route"
+      },
+      {
+        "name": "@ar4mirez/hapi-pres",
+        "link": "https://github.com/ar4mirez/hapi-pres",
+        "description": "Autoload pre-requirements for HapiJS routes from a directory."
       },
       {
         "name": "hapi-pulse",
@@ -629,6 +634,11 @@
         "name": "hapi-router",
         "link": "https://github.com/bsiddiqui/hapi-router",
         "description": "A plugin to automatically load your routes"
+      },
+      {
+        "name": "@ar4mirez/hapi-safe-route",
+        "link": "https://github.com/ar4mirez/hapi-safe-route",
+        "description": "Register routes in a safer way, avoiding server crash on duplicate routes while running or at startup time."
       },
       {
         "name": "hapi-sanitize-payload",


### PR DESCRIPTION
Updates two existing entries and adds two new plugins from [@ar4mirez](https://github.com/ar4mirez), all upgraded to **@hapi/hapi v21** and **Node >=18**.

### Updated
| Old name | New name | Change |
|----------|----------|--------|
| `hapi-aws` | `@ar4mirez/hapi-aws` | Migrated to AWS SDK v3, hapi v21 |
| `hapi-octopus` | `@ar4mirez/hapi-octopus` | Upgraded to hapi v21 |

### Added
| Package | Description |
|---------|-------------|
| `@ar4mirez/hapi-pres` | Autoload pre-requirements for HapiJS routes from a directory |
| `@ar4mirez/hapi-safe-route` | Register routes safely, avoiding server crash on duplicates |

All 4 packages are published on npm under the `@ar4mirez` scope and include CI + provenance-signed releases.