### PR TITLE
Add security plugin `hapi-aegis` to `plugins.json`

### DIFF
--- a/static/lib/plugins.json
+++ b/static/lib/plugins.json
@@ -365,6 +365,11 @@
         "description": "CSRF crumb generation and validation for hapi"
       },
       {
+        "name": "hapi-aegis",
+        "link": "https://github.com/mrosenlund/hapi-aegis",
+        "description": "Sets security-related HTTP response headers (CSP, HSTS, Frameguard, and more)"
+      },
+      {
         "name": "ralphi",
         "link": "https://github.com/yonjah/ralphi",
         "description": "Simple and minimal rate limiting and bruteforce protection"


### PR DESCRIPTION
Adds `hapi-aegis`, a newly-released hapi security-headers plugin, to the Security category.

- npm: https://www.npmjs.com/package/hapi-aegis
- GitHub: https://github.com/mrosenlund/hapi-aegis

hapi-aegis provides sensible defaults for Content-Security-Policy, Strict-Transport-Security, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Cross-Origin-* and more, with per-route overrides. Think Helmet (Express), but built natively for hapi. First public release: v1.0.0.